### PR TITLE
Skype link 404's because link does not exist

### DIFF
--- a/partials/navbar.hbs
+++ b/partials/navbar.hbs
@@ -15,10 +15,8 @@
         </a>
     </li>
         <li>
-        <a href="https://skype.com/mbejda2" target="_blank">
-
-<i class="el el-skype"></i>
-            mbejda2
+        <a href="skype:mbejda2?add" target="_blank">
+            <i class="el el-skype"></i> mbejda2
         </a>
 
     </li>


### PR DESCRIPTION
I fixed the skype link. When you try to visit a link like http://skype.com/<username> it just 404's. I added the `skype:<username>?<method>` url scheme so that when the skype link is clicked, it opens skype and adds the user as a contact. If you want, the `?add` can be replaced with `?chat` so that it just sends them a message instead of adding them as a contact. I believe having the action be adding them as a contact is reasonable, though.