### PR TITLE
Fix cover size

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -88,13 +88,17 @@ ul.menu li:hover {
 }
 .cover {
   background-size:cover !important;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 .blog-description h1 {
   font-size:25px;
   font-weight:300;
   line-height: 32px;
-  padding-bottom:20px;
-  border-bottom:10px solid rgba(64, 120, 192, 0.11);
+  border-bottom:10px solid rgba(64, 120, 192, 0.5);
+  display: inline-block;
+  padding: 0 20px 10px;
 }
 .summary header a {
   font-size:18px;
@@ -136,4 +140,16 @@ article.post img {
  width:100%;   
  margin-top:10px;
  margin-bottom:10px;
+}
+
+@media (min-width: 768px) {
+  .cover {
+    max-height: 200px;
+  }
+}
+
+@media (min-width: 1200px) {
+  .cover {
+    max-height: 240px;
+  }
 }

--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -142,6 +142,16 @@ article.post img {
  margin-bottom:10px;
 }
 
+article.post:first-child h2.title {
+  margin-top: 0;
+}
+
+@media (min-width: 576px) {
+  .blog-description h1 {
+    color: white;
+  }
+}
+
 @media (min-width: 768px) {
   .cover {
     max-height: 200px;

--- a/default.hbs
+++ b/default.hbs
@@ -57,9 +57,12 @@
 <body>
 {{#is "home"}}
     {{#if @blog.cover_image}}
-<div style="background:url({{@blog.cover_image}}) no-repeat center center;" class="cover cover-border hidden-sm hidden-xs">
-</div>
-{{/if}}
+        <div style="background:url({{@blog.cover_image}}) no-repeat center center;" class="cover cover-border hidden-sm hidden-xs">
+            <div class="blog-description">
+                <h1>{{@blog.description}}</h1>
+            </div>
+        </div>
+    {{/if}}
 {{/is}}
 <div class="container">
 <div class="row">

--- a/index.hbs
+++ b/index.hbs
@@ -1,7 +1,7 @@
 {{!< default}}
 {{! The tag above means - insert everything in this file into the {body} of the default.hbs template }}
-<div class="blog-description col-md-12">
-<h1>{{@blog.description}}</h1>
+<div class="blog-description col-md-12 visible-sm visible-xs">
+  <h1>{{@blog.description}}</h1>
 </div>
 {{! The main content area on the homepage }}
 {{! The tag below includes the post loop - partials/loop.hbs }}


### PR DESCRIPTION
The current layout would leave the blank cover image just right on the screen. I think we can place the blog description on the cover image like capser does would look better.